### PR TITLE
Implemented verify file hashes with rpm task (issue #498)

### DIFF
--- a/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
@@ -1,5 +1,5 @@
 - name: verify and correct file permissions
-  shell: for FILE_PATH in $(rpm -Va | grep '^.M'); do rpm --setperms $(rpm -qf "${FILE_PATH}"); done
+  shell: for FILE_PATH in $(rpm -Va | grep '^.M' | awk '{print $3}'); do rpm --setperms $(rpm -qf "${FILE_PATH}"); done
   args:
     executable: /bin/bash
   tags:
@@ -12,10 +12,41 @@
     - NIST-800-53-SI
     - NIST-800-53-SI-7
 
-- name: verify file hashes
-  debug:
-    msg: "tasks not yet implemented"
+- name: find files with hash values that deviate from the installed package
+  shell: rpm -Va | grep '^..5' | grep -v '^...........c' | awk '{print $2}'
+  register: deviants
   tags:
+    - CM-6(d) 
+    - CM-6(3) 
+    - SI-7(1)
+    - NIST-800-53
+    - NIST-800-53-CM
+    - NIST-800-53-CM-6
+    - NIST-800-53-SI
+    - NIST-800-53-SI-7
+
+- name: collect names of packages to be reinstalled
+  shell: "rpm -qf {{ item }}"
+  with_items: "{{ deviants.stdout_lines }}"
+  register: packages_to_reinstall
+  tags:
+    - CM-6(d)
+    - CM-6(3)
+    - SI-7(1)
+    - NIST-800-53
+    - NIST-800-53-CM
+    - NIST-800-53-CM-6
+    - NIST-800-53-SI
+    - NIST-800-53-SI-7
+
+- name: reinstall packages
+# yum module in Ansible does not include the "reinstall" command
+  shell: "yum reinstall {{ item.stdout_lines[0] }} -y"
+  with_items: "{{ packages_to_reinstall.results }}"
+  tags:
+    - CM-6(d)
+    - CM-6(3)
+    - SI-7(1)
     - NIST-800-53
     - NIST-800-53-CM
     - NIST-800-53-CM-6

--- a/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
@@ -1,8 +1,19 @@
 - name: verify and correct file permissions
-  shell: for FILE_PATH in $(rpm -Va | grep '^.M' | awk '{print $3}'); do rpm --setperms $(rpm -qf "${FILE_PATH}"); done
-  args:
-    executable: /bin/bash
+  shell: rpm -Va | grep '^.M' | awk '{ print $3 }'
+  register: wayward_files
   tags:
+    - NIST-800-53
+    - NIST-800-53-AC
+    - NIST-800-53-AC-6
+    - NIST-800-53-CM
+    - NIST-800-53-CM-6
+    - NIST-800-53-CM-6(d)
+    - NIST-800-53-SI
+    - NIST-800-53-SI-7
+
+- name: assign correct file permissions
+  shell: rpm --setperms $(rpm -qf "{{ item }}")
+  with_items: "{{ wayward_files.stdout_lines }}"
     - NIST-800-53
     - NIST-800-53-AC
     - NIST-800-53-AC-6
@@ -16,8 +27,8 @@
   shell: rpm -Va | grep '^..5' | grep -v '^...........c' | awk '{print $2}'
   register: deviants
   tags:
-    - CM-6(d) 
-    - CM-6(3) 
+    - CM-6(d)
+    - CM-6(3)
     - SI-7(1)
     - NIST-800-53
     - NIST-800-53-CM


### PR DESCRIPTION
Code tested successfully on RHEL7, AWS ec2 image.  Code is potentially inefficient due to not being able to bundle all package reinstalls into one shell command. Ansible shows a warning due to running yum via a shell command rather than the yum module. However, the Ansible yum module does not appear to support the "reinstall" command.