### PR TITLE
Implemented verify file hashes with rpm task (issue #498) 

### DIFF
--- a/tasks/system_settings/account_and_access_control/protect_accounts_by_configuring_pam.yml
+++ b/tasks/system_settings/account_and_access_control/protect_accounts_by_configuring_pam.yml
@@ -132,7 +132,7 @@
   lineinfile:
     dest: /etc/pam.d/system-auth
     insertbefore: "^auth.*pam_unix.so.*"
-    line: "auth         required      pam_faillock.so preauth silent deny=3 unlock_time=604800 fail_interval=900"
+    line: "auth         required      pam_faillock.so preauth silent deny=3 unlock_time=never fail_interval=900"
   tags:
   - AC
   - AC-7
@@ -142,7 +142,7 @@
   lineinfile:
     dest: /etc/pam.d/system-auth
     insertafter: "^auth.*pam_unix.so.*"
-    line: "auth      [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900"
+    line: "auth      [default=die] pam_faillock.so authfail deny=3 unlock_time=never fail_interval=900"
   tags:
   - AC
   - AC-7
@@ -158,11 +158,36 @@
   - AC-7
   - AC-7(a)
 
+- name: Configure even_deny_root for Failed Password Attempts in /etc/pam.d/system-auth
+  pamd:
+    name: system-auth
+    type: auth
+    control: required
+    module_path: pam_faillock.so
+    module_arguments: even_deny_root
+    state: args_present
+  tags:
+  - AC
+  - AC-7
+  - AC-7(a)
+- name: Configure even_deny_root for Failed Password Attempts in /etc/pam.d/password-auth
+  pamd:
+    name: password-auth
+    type: auth
+    control: '[default=die]'
+    module_path: pam_faillock.so
+    module_arguments: even_deny_root
+    state: args_present
+  tags:
+  - AC
+  - AC-7
+  - AC-7(a)
+
 - name: Set Deny, Lockout Time, and Interval Count For Failed Password Attempts in /etc/pam.d/password-auth (1/3)
   lineinfile:
     dest: /etc/pam.d/password-auth
     insertbefore: "^auth.*pam_unix.so.*"
-    line: "auth         required    pam_faillock.so preauth silent deny=3 unlock_time=604800 fail_interval=900"
+    line: "auth         required    pam_faillock.so preauth silent deny=3 unlock_time=never fail_interval=900"
   tags:
   - AC
   - AC-7
@@ -172,7 +197,7 @@
   lineinfile:
     dest: /etc/pam.d/password-auth
     insertafter: "^auth.*pam_unix.so.*"
-    line: "auth      [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900"
+    line: "auth      [default=die] pam_faillock.so authfail deny=3 unlock_time=never fail_interval=900"
   tags:
   - AC
   - AC-7

--- a/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
@@ -1,5 +1,5 @@
 - name: verify and correct file permissions
-  shell: for FILE_PATH in $(rpm -Va | grep '^.M'); do rpm --setperms $(rpm -qf "${FILE_PATH}"); done
+  shell: for FILE_PATH in $(rpm -Va | grep '^.M' | awk '{print $3}'); do rpm --setperms $(rpm -qf "${FILE_PATH}"); done
   args:
     executable: /bin/bash
   tags:
@@ -12,10 +12,41 @@
     - NIST-800-53-SI
     - NIST-800-53-SI-7
 
-- name: verify file hashes
-  debug:
-    msg: "tasks not yet implemented"
+- name: find files with hash values that deviate from the installed package
+  shell: rpm -Va | grep '^..5' | grep -v '^...........c' | awk '{print $2}'
+  register: deviants
   tags:
+    - CM-6(d) 
+    - CM-6(3) 
+    - SI-7(1)
+    - NIST-800-53
+    - NIST-800-53-CM
+    - NIST-800-53-CM-6
+    - NIST-800-53-SI
+    - NIST-800-53-SI-7
+
+- name: collect names of packages to be reinstalled
+  shell: "rpm -qf {{ item }}"
+  with_items: "{{ deviants.stdout_lines }}"
+  register: packages_to_reinstall
+  tags:
+    - CM-6(d)
+    - CM-6(3)
+    - SI-7(1)
+    - NIST-800-53
+    - NIST-800-53-CM
+    - NIST-800-53-CM-6
+    - NIST-800-53-SI
+    - NIST-800-53-SI-7
+
+- name: reinstall packages
+# yum module in Ansible does not include the "reinstall" command
+  shell: "yum reinstall {{ item.stdout_lines[0] }} -y"
+  with_items: "{{ packages_to_reinstall.results }}"
+  tags:
+    - CM-6(d)
+    - CM-6(3)
+    - SI-7(1)
     - NIST-800-53
     - NIST-800-53-CM
     - NIST-800-53-CM-6

--- a/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
@@ -14,6 +14,7 @@
 - name: assign correct file permissions
   shell: rpm --setperms $(rpm -qf "{{ item }}")
   with_items: "{{ wayward_files.stdout_lines }}"
+  tags:
     - NIST-800-53
     - NIST-800-53-AC
     - NIST-800-53-AC-6

--- a/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
@@ -1,8 +1,19 @@
 - name: verify and correct file permissions
-  shell: for FILE_PATH in $(rpm -Va | grep '^.M' | awk '{print $3}'); do rpm --setperms $(rpm -qf "${FILE_PATH}"); done
-  args:
-    executable: /bin/bash
+  shell: rpm -Va | grep '^.M' | awk '{ print $3 }'
+  register: wayward_files
   tags:
+    - NIST-800-53
+    - NIST-800-53-AC
+    - NIST-800-53-AC-6
+    - NIST-800-53-CM
+    - NIST-800-53-CM-6
+    - NIST-800-53-CM-6(d)
+    - NIST-800-53-SI
+    - NIST-800-53-SI-7
+
+- name: assign correct file permissions
+  shell: rpm --setperms $(rpm -qf "{{ item }}")
+  with_items: "{{ wayward_files.stdout_lines }}"
     - NIST-800-53
     - NIST-800-53-AC
     - NIST-800-53-AC-6
@@ -16,8 +27,8 @@
   shell: rpm -Va | grep '^..5' | grep -v '^...........c' | awk '{print $2}'
   register: deviants
   tags:
-    - CM-6(d) 
-    - CM-6(3) 
+    - CM-6(d)
+    - CM-6(3)
     - SI-7(1)
     - NIST-800-53
     - NIST-800-53-CM

--- a/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
@@ -1,28 +1,14 @@
-- name: verify and correct file permissions
-  shell: rpm -Va | grep '^.M' | awk '{ print $3 }'
-  register: wayward_files
-  tags:
-    - NIST-800-53
-    - NIST-800-53-AC
-    - NIST-800-53-AC-6
-    - NIST-800-53-CM
-    - NIST-800-53-CM-6
-    - NIST-800-53-CM-6(d)
-    - NIST-800-53-SI
-    - NIST-800-53-SI-7
 
-- name: assign correct file permissions
-  shell: rpm --setperms $(rpm -qf "{{ item }}")
-  with_items: "{{ wayward_files.stdout_lines }}"
-  tags:
-    - NIST-800-53
-    - NIST-800-53-AC
-    - NIST-800-53-AC-6
-    - NIST-800-53-CM
-    - NIST-800-53-CM-6
-    - NIST-800-53-CM-6(d)
-    - NIST-800-53-SI
-    - NIST-800-53-SI-7
+- name: "Read list of files with incorrect permissions"
+  shell: "rpm -Va | grep '^.M' | sed -r 's;^.*\\s+(.+);\\1;g'"
+  register: files_with_incorrect_permissions
+  failed_when: False
+  changed_when: False
+
+- name: "Correct file permissions with RPM"
+  shell: "rpm --setperms $(rpm -qf '{{item}}')"
+  with_items: "{{ files_with_incorrect_permissions.stdout_lines }}"
+  when: files_with_incorrect_permissions.stdout_lines | length > 0
 
 - name: find files with hash values that deviate from the installed package
   shell: rpm -Va | grep '^..5' | grep -v '^...........c' | awk '{print $2}'


### PR DESCRIPTION
Code tested successfully on RHEL7, AWS ec2 image. Code is potentially inefficient due to not being able to bundle all package reinstalls into one shell command. Ansible shows a warning due to running yum via a shell command rather than the yum module. However, the Ansible yum module does not appear to support the "reinstall" command.