### PR TITLE
General Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Example Playbook
 ----------------
 
 ```yaml
-# file: 80053.yaml
+# file: compliant.yaml
 ---
-- hosts: 80053_hosts
+- hosts: compliant_hosts
   become: yes
   vars:
     scap_reports_dir: ~/scap_reports
@@ -72,7 +72,7 @@ Example Inventory
 -----------------
 
 ```ini
-[80053_hosts]
+[compliant_hosts]
 172.16.78.159
 ```
 
@@ -80,7 +80,7 @@ Example Run
 -----------
 
 ```bash
-ansible-playbook -u admin -i 80053_inventory 80053.yaml
+ansible-playbook -u admin -i inventory compliant.yaml
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,6 @@ rpm_keys:
     - RPM-GPG-KEY-CentOS-7
     - RPM-GPG-KEY-CentOS-Debug-7
     - RPM-GPG-KEY-CentOS-Testing-7
-    - RPM-GPG-KEY-EPEL-7
   fedora_27:
     - RPM-GPG-KEY-fedora-27-primary
     - RPM-GPG-KEY-fedora-27-secondary

--- a/library/aide_ruleset.py
+++ b/library/aide_ruleset.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2017, Kenneth D. Evensen <kdevensen@gmail.com>
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+module: aide_ruleset
+author:
+    - "Kenneth D. Evensen (@kevensen)"
+short_description: Manage AIDE Rule Sets
+description:
+  - Edit an AIDE ruleset in specified AIDE configuration file. See
+    man(5) aide.conf for details.
+version_added: "2.6"
+options:
+
+"""
+
+EXAMPLES = """
+
+"""
+
+RETURN = '''
+
+...
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import re
+from tempfile import NamedTemporaryFile
+
+PATTERN = r"(?P<name>^[A-Z_]+)\s?=\s?(?P<options>.*)$"
+RULESET_REGEX = re.compile(PATTERN, re.MULTILINE)
+
+def add_options(existing_options, options_to_add):
+    changed = False
+    options_added = []
+
+    # Create a list of new args that aren't already present
+    options_added = [option for option in options_to_add if option not in existing_options]
+    
+    if options_added:
+        existing_options = existing_options + options_added
+        changed = True
+
+    return changed, existing_options, options_added
+
+def remove_options(existing_options, options_to_remove):
+    changed = False
+    options_removed = []
+
+    # Let's check to see if there are any args to remove by finding the intersection
+    # of the rule's current args and the args_to_remove lists
+    if list(set(existing_options) & set(options_to_remove)):
+        # There are args to remove, so we create a list of new_args absent the args
+        # to remove.
+        existing_options = [option for option in existing_options if option not in options_to_remove]
+        options_removed = [option for option in existing_options if option in options_to_remove]
+        changed = True
+
+
+    return changed, existing_options, options_removed
+
+def ruleset_pattern(name):
+    return r"^" + name + r"\s?=\s?.*$"
+
+def update_content(content, rulesets):
+    # Update the content
+    for ruleset, options in rulesets.iteritems():
+        replacement = ruleset + " = " + "+".join(options)
+        content = re.sub(ruleset_pattern(ruleset), replacement, content)
+
+    return content
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True, type='str'),
+            conf_path=dict(required=False, default='/etc/aide.conf', type='path'),
+            options=dict(required=False, type='list'),
+            options_string=dict(required=False, type='str'),
+            state=dict(required=False, default="updated",
+                       choices=['absent', 'present', 'updated']),
+            backup=dict(default=False, type='bool'),
+            add_if_not_present=dict(default=False, required=False)
+        ),
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ['options', 'options_string']
+        ],
+        required_one_of=[
+            ['options', 'options_string']
+        ]
+    )
+    # For existing rule sets
+    rulesets = dict()
+    content = str()
+    options = []
+    options_changed = []
+    existing_options = []
+    backupdest = ""
+    fname = module.params['conf_path']
+    action = module.params['state']
+    add_if_not_present = module.params['add_if_not_present']
+    ruleset_name = module.params['name'].rstrip().lstrip()
+
+    # Get the options from either the 'options' or 'options_string' module arguments
+    if module.params['options']:
+        options = module.params['options']
+    else:
+        options = module.params['options_string'].split('+')
+
+    # Open the file and read the content or fail
+    try:
+        with open(fname, 'r') as aide_file_obj:
+            content = aide_file_obj.read()
+    except IOError as e:
+        # If unable to read the file, fail out
+        module.fail_json(msg='Unable to open/read AIDE configuration \
+                            file %s with error %s.' %
+                         (fname, str(e)))
+    matches = RULESET_REGEX.findall(content)
+    # Load existing rule set
+    for match in matches:
+        existing_options = match[1].split('+')
+        rulesets[match[0]] = existing_options
+
+    module.log(msg="EXISTING RULESET KEYS: " + str(rulesets.keys()))
+    module.log(msg="EXISTING RULESET: " + str(rulesets))
+
+    # Take action
+    if action == 'absent':
+        changed, rulesets[ruleset_name], options_changed = remove_options(rulesets[ruleset_name], options)
+    elif action == 'present':
+        changed, rulesets[ruleset_name], options_changed = add_options(rulesets[ruleset_name], options)
+    elif action == 'updated':
+        if ruleset_name in rulesets.keys() or add_if_not_present:
+            rulesets[ruleset_name] = options
+            options_changed = options
+            changed = True
+
+
+    # Write file
+    if not module.check_mode and changed:
+        module.log(msg="WRITING")
+        # Update the content
+        pattern = r"^" + ruleset_name + r"\s?=\s?.*$"
+        module.log(msg="PATTERN: " + pattern)
+        replacement = ruleset_name + " = " + "+".join(rulesets[ruleset_name])
+        module.log(msg="REPLACEMENT: " + replacement)
+        new_content = re.sub(pattern, replacement, content, flags=re.MULTILINE)
+        
+        module.log(msg="OLD CONTENT equals NEW CONTENT: " + str(content == new_content))
+        # First, create a backup if desired.
+        if module.params['backup']:
+            backupdest = module.backup_local(fname)
+        # Write the file
+        try:
+            temp_file = NamedTemporaryFile(mode='w')
+            module.log(msg="TEMP FILE NAME: " + temp_file.name)
+            with open(temp_file.name, 'w') as fd:
+                fd.write(new_content)
+
+        except IOError:
+            module.fail_json(msg='Unable to create temporary \
+                                    file %s' % temp_file)
+
+        module.atomic_move(temp_file.name, fname)
+
+
+    facts = {}
+    facts['aide_ruleset'] = {'action': action,
+                             'name': ruleset_name,
+                             'existing_options': existing_options,
+                             'options_changed': options_changed,
+                             'backupdest': backupdest}
+
+    module.exit_json(changed=changed, ansible_facts=facts)
+
+if __name__ == '__main__':
+    main()

--- a/tasks/finalize.yml
+++ b/tasks/finalize.yml
@@ -60,6 +60,20 @@
     - MP
     - MP-2
 
+- name: fedoraredteam.compliant | Configure Notification of Post-AIDE Scan Details
+  cron:
+    job: /usr/sbin/aide --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost
+    day: "{{ aide_day_of_month }}"
+    hour: "{{ aide_hour }}"
+    minute: "{{ aide_minute }}"
+    month: "{{ aide_day_of_month }}"
+    weekday: "{{ aide_day_of_week }}"
+  tags:
+   - NIST-800-53-CM
+   - NIST-800-53-CM-3
+   - NIST-800-53-CM-3(5)
+   - SRG-OS-000363-GPOS-00150
+
 - name: Build AIDE Database
   shell: /usr/sbin/aide --init
   args:

--- a/tasks/scap.yml
+++ b/tasks/scap.yml
@@ -3,6 +3,8 @@
 - stat:
     path: /etc/yum.repos.d/redhat-rhui.repo
   register: rhui_repo
+  tags:
+  - scap
 
 #- block:
 #  - name: Install Open SCAP scanner
@@ -30,6 +32,8 @@
     name: openscap-scanner, scap-security-guide
     state: installed
   when: rhui_repo.stat.isreg is undefined or rhui_repo.stat.isreg == False
+  tags:
+  - scap
 
 
 - block:
@@ -77,12 +81,21 @@
 #    - scap
 
 - block:
-  - name: Run an SCAP scan and Generate Report EL 7
+  - name: Run an SCAP scan and Generate Report RHEL 7
     command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-rhel{{ ansible_distribution_major_version }}-xccdf.xml
-    failed_when: "result | failed and result.rc == 1"
+    failed_when: "result is failed and result.rc == 1"
     register: result
     with_items: "{{ scap_profile_rhel7 }}"
-    when: run_scap and ansible_distribution_major_version == "7"
+    when: run_scap and ansible_distribution_major_version == "7" and ansible_distribution == "RedHat"
+    tags:
+      - scap
+  
+  - name: Run an SCAP scan and Generate Report CentOS 7
+    command: /usr/bin/oscap xccdf eval --profile "{{ item }}" --results /tmp/scap_reports/scan-xccdf-results-{{ ansible_date_time.iso8601  }}-{{ item }}.xml --report /tmp/scap_reports/scan-xccdf-report-{{ ansible_date_time.iso8601  }}-{{ item }}.html  /usr/share/xml/scap/ssg/content/ssg-centos{{ ansible_distribution_major_version }}-xccdf.xml
+    failed_when: "result is failed and result.rc == 1"
+    register: result
+    with_items: "{{ scap_profile_rhel7 }}"
+    when: run_scap and ansible_distribution_major_version == "7" and ansible_distribution == "CentOS"
     tags:
       - scap
 

--- a/tasks/system_settings/account_and_access_control/protect_accounts_by_configuring_pam.yml
+++ b/tasks/system_settings/account_and_access_control/protect_accounts_by_configuring_pam.yml
@@ -170,6 +170,7 @@
   - AC
   - AC-7
   - AC-7(a)
+  
 - name: Configure even_deny_root for Failed Password Attempts in /etc/pam.d/password-auth
   pamd:
     name: password-auth

--- a/tasks/system_settings/installing_and_maintaining_software/software_integrity_checking/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/software_integrity_checking/redhat.yml
@@ -92,4 +92,61 @@
     - NIST-800-53-CM-6(d)
     - NIST-800-53-CM-6(3)
 
+- block:
+  - name: System Settings | Installing and Maintaining Software | Software Integrity Checking | Red Hat | Obtain custom policy rule sets from /etc/aide.conf
+    shell: /bin/grep "^[A-Z]\+" /etc/aide.conf | /bin/cut -f1 -d '=' | /bin/tr -d ' ' | /bin/sort -u
+    args:
+      executable: /bin/bash
+    register: aide_policy_groups
+    changed_when: False
 
+  - debug:
+      var: aide_policy_groups
+
+  - name: System Settings | Installing and Maintaining Software | Software Integrity Checking | Red Hat | Configure AIDE to Verify Access Control Lists (ACLs)
+    aide_ruleset:
+      name: "{{ item }} "
+      state: present
+      options:
+      - acl
+    with_items:
+    - "{{ aide_policy_groups.stdout_lines }}"
+    
+  - name: System Settings | Installing and Maintaining Software | Software Integrity Checking | Red Hat | Configure AIDE to Verify Extended Attributes
+    aide_ruleset:
+      name: "{{ item }} "
+      state: present
+      options:
+      - xattrs
+    with_items:
+    - "{{ aide_policy_groups.stdout_lines }}"
+
+  - name: System Settings | Installing and Maintaining Software | Software Integrity Checking | Red Hat | Configure AIDE to Use FIPS 140-2 for Validating Hashes
+    aide_ruleset:
+      name: "{{ item }} "
+      state: present
+      options:
+      - sha512
+    with_items:
+    - "{{ aide_policy_groups.stdout_lines }}"
+
+  - name: System Settings | Installing and Maintaining Software | Software Integrity Checking | Red Hat | Configure AIDE to Use FIPS 140-2 - Remove Forbidden Hashes
+    aide_ruleset:
+      name: "{{ item }} "
+      state: absent
+      options:
+      - sha1
+      - rmd160
+      - sha256
+      - whirlpool
+      - tiger
+      - haval
+      - gost
+    with_items:
+    - "{{ aide_policy_groups.stdout_lines }}"
+
+  tags:
+  - NIST-800-53-SI-7.1
+  - NIST-800-53-SI-7
+  - NIST-800-53-SI
+  - SRG-OS-000480-GPOS-00227

--- a/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
+++ b/tasks/system_settings/installing_and_maintaining_software/updating_software/redhat.yml
@@ -147,6 +147,17 @@
     - NIST-800-53-MA-1
     - NIST-800-53-MA-1(b)
 
+- name: System Settings | Installing and Maintaining Software | Updating Software | Determine if EPEL Repo is Enabled
+  command: yum repolist | awk '{ print $1 }' | grep -v 'repolist' | grep -v '*' | grep -v 'Load' | grep epel
+  register: epelrepo
+
+- name: System Settings | Installing and Maintaining Software | Updating Software | Ensure Package Manager GPG Keys are Installed for EPEL
+  rpm_key:
+    state: present
+    key: "/etc/pki/rpm-gpg/{{ item }}"
+  when: epelrepo.rc == "1"
+  
+
 - name: ensure gpgcheck enabled for package manager
   lineinfile:
     path: /etc/yum.conf

--- a/tasks/system_settings/network_configuration_and_firewalls/firewalld.yml
+++ b/tasks/system_settings/network_configuration_and_firewalls/firewalld.yml
@@ -3,6 +3,14 @@
     path: /etc/firewalld/firewalld.conf
   register: firewalld
 
+- name: fedoraredteam.compliant | Enable SSH Server firewalld Firewall exception
+  command: firewall-cmd --permanent --add-service=ssh --zone=drop
+  when:
+  - firewalld.stat.exists == true
+  tags:
+  - CM
+  - CM-7
+
 - name: Set Default firewalld Zone for Incoming Packets
   lineinfile:
     dest: /etc/firewalld/firewalld.conf
@@ -13,3 +21,4 @@
   tags:
   - CM
   - CM-7
+


### PR DESCRIPTION
- Updated README.md to reflect new role name

- Changed how the GPG key for EPEL is verified.  If the EPEL repo isn't installed, the check for this key is now ignored.

- Added module to manipulate the AIDE rulesets.  This is now a bit more idempotent than **lineinfile**.  As an aside I know I had suggested we should only use Ansible Core modules and avoid community modules..  I'm now rethinking that.  Perhaps we can include _community_ modules if we are the ones who maintains them.  @patrickmryan is updating **pamd**.  I think if we are the ones to maintain the module's baseline, we reduce the risk bugs making their way into the playbook run.

- Enabled post AIDE scan notifications

- Added **scap** tags to SCAP relevant tasks

- Improved AIDE rulesets

- After configuring **firewalld** to drop packets by default, the host was dropping SSH connections making it so secure, Ansible couldn't be run again.  A task to enable SSH for the **drop** zone as been added.